### PR TITLE
Add error for loop requiring a vector

### DIFF
--- a/src/errors/error_dictionary.clj
+++ b/src/errors/error_dictionary.clj
@@ -295,6 +295,18 @@
     :match (beginandend "Duplicate key: (\\S*)")
     :make-msg-info-obj (fn [matches] (make-msg-info-hashes "You cannot use the same key in a hash-map twice, but you have duplicated the key " (nth matches 1) :arg ".\n"))}
 
+    {:key :loop-req-vector
+    :class "IllegalArgumentException"
+    :match (beginandend "loop requires a vector for its binding (\\S*)")
+    :make-msg-info-obj (fn [matches] (make-msg-info-hashes "Loop requires a vector for its binding.\n"))}
+
+    {:key :recur-arg-mismatch
+    :class "IllegalArgumentException"
+    :match (beginandend #"Mismatched argument count to recur, expected: (.*) args, got: (.*)\,")
+    :make-msg-info-obj (fn [matches] (make-msg-info-hashes "Mismatch between the number of arguments of outside function and recur: recur must take " (nth matches 1) " argument(s) but was given " (nth matches 2) :arg ".\n"))}
+
+
+  ;;(beginandend #"Call to (.*)/(.*) did not conform to spec:(.*)In: (.*) val: (.*) fails spec: :clojure\.core\.specs\.alpha/local-name (.*) predicate: simple-symbol\?")
    ;########################
    ;### Assertion Errors ###
    ;########################

--- a/test/babel/error_tests.clj
+++ b/test/babel/error_tests.clj
@@ -87,6 +87,12 @@
 
 (expect "Too few arguments to if.\n" (get-error "(if (= 0 0))"))
 
+(expect "Loop requires a vector for its binding.\n" (get-error "(loop x 5 (+ x 5))"))
+
+(expect "Mismatch between the number of arguments of outside function and recur: recur must take 1 argument(s) but was given 2.\n" (get-error "(defn reduce-to-zero [x] (if (= x 0) x (recur reduce-to-zero (- x 1))))"))
+
+(expect "Mismatch between the number of arguments of outside function and recur: recur must take 1 argument(s) but was given 2.\n" (get-error "(loop [x 5] (if (< x 1) \"hi\" (recur (dec x) (print x))))"))
+
 ;; it doesn't look like we can run this test; works correctly in repl
 #_(expect "Clojure ran out of memory, likely due to an infinite computation.\n" (get-error "(range)"))
 


### PR DESCRIPTION
Add error for recur requiring same number of arguments as the outside function

Add associated tests for both errors