### PR TITLE
Processor update

### DIFF
--- a/src/babel/processor.clj
+++ b/src/babel/processor.clj
@@ -6,22 +6,23 @@
              [corefns.corefns :as cf]))
 
 ;;an atom that record original error response
-(def recorder (atom {:msg "" :detail ""}))
+(def recorder (atom {:msg [] :detail []}))
 
 (defn reset-recorder
   "This function reset the recorder atom"
   []
-  (reset! recorder {:msg "" :detail ""}))
+  (reset! recorder {:msg [] :detail []}))
 
 (defn update-recorder-msg
   "takes an unfixed error message, and put it into the recorder"
   [inp-message]
-  (swap! recorder assoc :msg inp-message))
+  (swap! recorder update-in [:msg] conj inp-message))
+  ;(swap! recorder assoc :msg inp-message))
 
 (defn update-recorder-detail
   "takes error message details, and put them into the recorder"
   [inp-message]
-  (swap! recorder assoc :detail inp-message))
+  (swap! recorder update-in [:detail] conj inp-message))
 
 (defn modify-errors
   "takes a nREPL response, and returns a message with the errors fixed"

--- a/src/loggings/html_log.clj
+++ b/src/loggings/html_log.clj
@@ -97,8 +97,8 @@
                function colorBlindMode() {
                  var x = document.getElementsByClassName(\"modifiedError\");
                  var y = document.getElementsByClassName(\"originalError\");
-                 var p = document.getElementById(\"modified\");
-                 var q = document.getElementById(\"original\");
+                 var p = document.getElementById(\"modifiedA\");
+                 var q = document.getElementById(\"originalA\");
                  if (document.getElementById(\"colorBlind\").checked == true) {
                    var i;
                    for (i = 0; i < x.length; i++) {
@@ -131,8 +131,8 @@
          [:p {:style "padding-left:5px"} "Display options:"]
           [:div
            [:input#nil {:type "checkbox" :checked true :onclick "hidenils()"} [:a {:style "color:#808080;padding-right:20px"} "nil error"]]
-           [:input#modified {:type "checkbox" :checked true :onclick "hideModified()"} [:a {:style "color:#00AE0C;padding-right:20px"}"modified error"]]
-           [:input#original {:type "checkbox" :checked true :onclick "hideOriginal()"} [:a {:style "color:#D10101;padding-right:20px"} "original error"]]
+           [:input#modified {:type "checkbox" :checked true :onclick "hideModified()"} [:a#modifiedA {:style "color:#00AE0C;padding-right:20px"}"modified error"]]
+           [:input#original {:type "checkbox" :checked true :onclick "hideOriginal()"} [:a#originalA {:style "color:#D10101;padding-right:20px"} "original error"]]
            [:input#detail {:type "checkbox" :checked false :onclick "hideDetail()"} "error detail"]
            [:input#colorBlind {:type "checkbox" :checked false :onclick "colorBlindMode()":style "text-align:right;float:right"} [:a {:style "text-align:right;float:right"}  "Color blind mode"]]]]
         [:div#loadingError {:style "display:block"}

--- a/src/loggings/html_log.clj
+++ b/src/loggings/html_log.clj
@@ -218,7 +218,7 @@
 ;;saves the content into the txt log file
 (defn save-log
   [inp-code total modified original]
-  (spit "./log/last_test.txt" (log-content inp-code total modified original) :append true))
+  (spit "./log/last_test.txt" (log-content inp-code total modified (subs original 1 (- (.length original) 1))) :append true))
 
 ;;read the exsiting txt log content
 ;;this is disabled because it is removed from the middleware
@@ -253,5 +253,5 @@
 
 ;;write html content
 (defn write-html
-  [inp-code total partial modified origitnal detail]
-  (spit (str "./log/history/" current-time ".html") (html-content inp-code total partial modified origitnal detail) :append true))
+  [inp-code total partial modified original detail]
+  (spit (str "./log/history/" current-time ".html") (html-content inp-code total partial modified (subs original 1 (- (.length original) 1)) detail) :append true))


### PR DESCRIPTION
Firstly this patch fixed colorblind mode for the display option panel.
Most importantly this patch fixed original display bug. Now they can display properly.
I left the potential ability for the logging system to display multiple errors. Just need a little change in the  ``loggingtool.clj``.