### PR TITLE
make specs always load

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,5 +16,6 @@
   :repl-options {:nrepl-middleware
                  [babel.middleware/interceptor]
                  :port 7888};)
+   :injections [(require 'corefns.corefns)]
    :main utilities.spec_generator)
    ;:main specfiletesting.core)

--- a/src/babel/middleware.clj
+++ b/src/babel/middleware.clj
@@ -1,7 +1,6 @@
 (ns babel.middleware
   (:require [babel.processor :as processor]
-            [clojure.tools.nrepl.middleware]
-            [corefns.corefns :as corefns])
+            [clojure.tools.nrepl.middleware])
   (:import clojure.tools.nrepl.transport.Transport))
 
 (defn interceptor

--- a/src/babel/middleware.clj
+++ b/src/babel/middleware.clj
@@ -1,6 +1,7 @@
 (ns babel.middleware
   (:require [babel.processor :as processor]
-            [clojure.tools.nrepl.middleware])
+            [clojure.tools.nrepl.middleware]
+            [corefns.corefns :as corefns])
   (:import clojure.tools.nrepl.transport.Transport))
 
 (defn interceptor


### PR DESCRIPTION
injections in project.clj will always be evaluated before other code,
unless we in a jar or uberjar
if we are in a jar or uberjar, then we are likely being used as a
middleware, so placing a require in the middleware namespace will also
ensure that specs are loaded.