### PR TITLE
Add errors for various macro spec errors for no arguments or names, and accompanying tests

### DIFF
--- a/src/errors/error_dictionary.clj
+++ b/src/errors/error_dictionary.clj
@@ -19,22 +19,27 @@
     :make-msg-info-obj (fn [matches] (make-msg-info-hashes "Parameters for " (nth matches 2) :arg
     " must come in pairs, but one of them does not have a match.\n"))}
 
-    {:key :vector-expected-for-bindings
-     :class "ExceptionInfo"
-     :match (beginandend #"Call to (.*)/(.*) did not conform to spec:(.*)In: (.*) val: (.*) fails spec: :clojure\.core\.specs\.alpha/bindings (.*) predicate: vector\?")
-     :make-msg-info-obj (fn [matches] (make-msg-info-hashes "Parameters for " (nth matches 2) :arg " require a vector, but " (nth matches 5) :arg " was given instead.\n"))}
+   {:key :vector-expected-for-bindings
+    :class "ExceptionInfo"
+    :match (beginandend #"Call to (.*)/(.*) did not conform to spec:(.*)In: (.*) val: (.*) fails spec: :clojure\.core\.specs\.alpha/bindings (.*) predicate: vector\?")
+    :make-msg-info-obj (fn [matches] (make-msg-info-hashes "Parameters for " (nth matches 2) :arg " require a vector, but " (nth matches 5) :arg " was given instead.\n"))}
 
     {:key :binding-requires-a-pair
      :class "ExceptionInfo"
-     :match (beginandend #"Call to (.*)/(.*) did not conform to spec(.*):clojure\.core\.specs\.alpha/binding(.*)predicate: any\?,  Insufficient input")
+     :match (beginandend #"Call to (.*)/(.*) did not conform to spec(.*):clojure\.core\.specs\.alpha/binding(.*)predicate: any\?,  Insufficient input(.*):args \((.*)\[(.*)\](.*)\)}")
      :make-msg-info-obj (fn [matches] (make-msg-info-hashes "Parameters for " (nth matches 2) :arg
-     " must be a pair, but only one element is given.\n"))}
+     " must be a pair, but only " (nth matches 7) :arg " is given.\n"))}
 
-     {:key :extra-input-for-a-binding
-      :class "ExceptionInfo"
-      :match (beginandend #"Call to (.*)/(.*) did not conform to spec(.*):clojure\.core\.specs\.alpha/binding (.*)Extra input")
-      :make-msg-info-obj (fn [matches] (make-msg-info-hashes "Parameters for " (nth matches 2) :arg
-      " must be only one name and one value, but more parameters were given.\n"))}
+   {:key :binding-insufficient-input
+    :class "ExceptionInfo"
+    :match (beginandend #"Call to (.*)/(.*) did not conform to spec:(.*):clojure.core.specs.alpha/binding(.*)\"Insufficient input\"")
+    :make-msg-info-obj (fn [matches] (make-msg-info-hashes "An argument for " (nth matches 2) " required a binding but no binding was provided.\n"))}
+
+    {:key :extra-input-for-a-binding
+     :class "ExceptionInfo"
+     :match (beginandend #"Call to (.*)/(.*) did not conform to spec(.*):clojure\.core\.specs\.alpha/binding (.*)Extra input(.*):args \((.*)\[(.*)\](.*)\)}")
+     :make-msg-info-obj (fn [matches] (make-msg-info-hashes "Parameters for " (nth matches 2) :arg
+     " must be only one name and one value, but "(nth matches 7) :arg " were given.\n"))}
 
    {:key :wrong-binding-name
     :class "ExceptionInfo"
@@ -68,14 +73,20 @@
     :match (beginandend #"Call to (.*)/(.*) did not conform to spec:(.*)In: (.*) val: (.*) fails spec: :clojure\.core\.specs\.alpha/arg-list (.*) predicate: vector\?")
     :make-msg-info-obj (fn [matches] (make-msg-info-hashes "An argument for " (nth matches 2) :arg " required a vector, but no vector was passed.\n"))}\
 
-  ;  {:key :insufficient-input
-  ;   :class "ExceptionInfo"
-  ;   :match (beginandend #"Call to (.*)/(.*) did not conform to spec:\n(.*) :reason Insufficient Input")
-  ;   :make-msg-info-obj (fn [matches] (make-msg-info-hashes "There was insuffieint input for a function call\n"))}\
+  {:key :vector-expected
+    :class "ExceptionInfo"
+    :match (beginandend #"Call to (.*)/(.*) did not conform to spec:(.*)In: (.*) val: (.*) fails at: (.*) predicate: vector\?")
+    :make-msg-info-obj (fn [matches] (make-msg-info-hashes "An argument for " (nth matches 2) :arg " required a vector, but was given " (nth matches 5) :arg " instead.\n"))}
 
+  {:key :argument-expected-none-given
+    :class "ExceptionInfo"
+    :match (beginandend #"Call to (.*)/(.*) did not conform to spec:(.*)predicate:(.*)Insufficient input(.*) :value nil, :args nil")
+    :make-msg-info-obj (fn [matches] (make-msg-info-hashes "An argument for " (nth matches 2) :arg " was required but wasn't given.\n"))}
 
-
-
+   {:key :another-argument-expected
+    :class "ExceptionInfo"
+    :match (beginandend #"Call to (.*)/(.*) did not conform to spec:(.*)predicate:(.*):arity-1 :clojure\.core\.specs\.alpha/args\+body :arity-n(.*)Insufficient input(.*):args \((.*)\)}")
+    :make-msg-info-obj (fn [matches] (make-msg-info-hashes "Another argument for " (nth matches 2) :arg " was expected after " (nth matches 7) :arg ".\n"))}
 
    {:key :length-not-greater-zero
     :class "ExceptionInfo"

--- a/test/babel/spec_macro_tests.clj
+++ b/test/babel/spec_macro_tests.clj
@@ -30,18 +30,30 @@
 (expect "Parameters for let require a vector, but a was given instead.\n"
         (get-error " (let a (+ a 2))"))
 
+(expect "Parameters for let require a vector, but a was given instead.\n"
+        (get-error " (let a)"))
+
+(expect "An argument for let required a binding but no binding was provided.\n"
+        (get-error " (let )"))
+
 ;############################################
 ;#### Testing for 'let-like forms ###########
 ;############################################
 
-(expect "Parameters for if-let must be a pair, but only one element is given.\n"
+(expect "Parameters for if-let must be a pair, but only x is given.\n"
         (get-error "(if-let [x] x)"))
 
-(expect "Parameters for if-let must be only one name and one value, but more parameters were given.\n"
+(expect "Parameters for if-let must be only one name and one value, but x 2 y were given.\n"
         (get-error "(if-let [x 2 y] x)"))
 
 (expect "In let 2 is used instead of a variable name.\n"
         (get-error "(let [2 3] 8)"))
+
+(expect "An argument for if-let required a binding but no binding was provided.\n"
+        (get-error "(if-let)"))
+
+(expect "An argument for if-let required a vector, but was given a instead.\n"
+        (get-error "(if-let a)"))
 
 ;############################################
 ;#### Testing for 'defn' ###########
@@ -59,6 +71,17 @@
 (expect "An argument for defn- required a vector, but x was given instead.\n"
         (get-error "(defn- afunc2 x (+ 3 x))"))
 
+(expect "Another argument for defn was expected after a.\n"
+        (get-error "(defn a)"))
+
+(expect "Another argument for defn- was expected after a.\n"
+        (get-error "(defn- a)"))
+
+(expect "An argument for defn was required but wasn't given.\n"
+        (get-error "(defn)"))
+
+(expect "An argument for defn- was required but wasn't given.\n"
+        (get-error "(defn-)"))
 ;############################################
 ;#### Testing for 'fn' ###########
 ;############################################
@@ -73,6 +96,12 @@
 
 (expect "An argument for fn required a vector, but p was given instead.\n"
         (get-error "(let [x 7] (fn [r] (fn p (+ p p))))"))
+
+(expect "Another argument for fn was expected after a.\n"
+        (get-error "(fn a)"))
+
+(expect "An argument for fn was required but wasn't given.\n"
+        (get-error "(fn)"))
 
 ;############################################
 ;#### Testing for 'if-some' ###########
@@ -89,3 +118,6 @@
 
 (expect "if-some can only take two or three arguments; recieved one argument.\n"
         (get-error "(if-some [a 2])"))
+
+(expect "if-some can only take two or three arguments; recieved no arguments.\n"
+        (get-error "(if-some)"))


### PR DESCRIPTION
This merge will fix (defn) and similar macros without arguments (or too few) from giving back an unprocessed spec error