### PR TITLE
Refactoring filter-path and spec-message

### DIFF
--- a/src/babel/processor.clj
+++ b/src/babel/processor.clj
@@ -79,15 +79,16 @@
   (if (= (count vector-of-keywords) 1) (name (spec-ref (first vector-of-keywords))) (name (spec-ref (second vector-of-keywords)))))
 
 (defn has-alpha-nil?
-  [error-map]
-  (not (.contains (:path error-map) :clojure.spec.alpha/nil)))
+  [{:keys [path]}]
+  (.contains path :clojure.spec.alpha/nil))
 
 (defn filter-path
    "Filters through a list of paths removing any hashmap that contains :reason or :clojure.spec.apha/nil"
    [error-maps]
    (if (> (count error-maps) 1)
-       (filter #(not (contains? % :reason))
-               (filter has-alpha-nil? error-maps))
+       (->> error-maps
+            (filter #(not (has-alpha-nil? %)))
+            (filter #(not (contains? % :reason))))
        error-maps))
 
 ; (defn choose-path

--- a/src/babel/processor.clj
+++ b/src/babel/processor.clj
@@ -92,18 +92,6 @@
             (filter #(not (contains? % :reason))))
        problem-maps))
 
-; (defn choose-path
-;   "Returns correct path based on conditions when given a list which should be of a :clojure.spec.alpha.problems that contains a list of paths.
-;    Its default case should be when the :path contains nil because of the nilable path which we never want to return because it gives null pointer.
-;    Its purpose is to check for :reason which is the wrong path because of how spec is structured,
-;    it removes this path through recursion until you get the correct path for the spec error."
-  ; (cond
-  ;   (= (count list-of-paths) 1) list-of-paths
-  ;   (= (first list-of-paths) nil) {:path [:wrong-path] :pred :val :via "function" :in [0]} ;Should never happen
-  ;   (.contains ((first list-of-paths) :path) :clojure.spec.alpha/nil) (choose-path (rest list-of-paths)) ;checks if path contains nil through .contains
-  ;   (contains? (first list-of-paths) :reason) (choose-path (rest list-of-paths)) ;checks if path contains reason
-  ;   :else (first list-of-paths))) ;return the first
-
 (defn spec-message
   "Takes ex-info data of a spec error, returns a modified message as a string"
   [{problem-list :clojure.spec.alpha/problems

--- a/src/babel/processor.clj
+++ b/src/babel/processor.clj
@@ -83,14 +83,14 @@
   (.contains path :clojure.spec.alpha/nil))
 
 (defn filter-extra-spec-errors
-   "error-maps looks like [{:path [:a :b ...] ~~} {:path [] ~~} ...]
-   Filters through error-maps removing any map that contains :clojure.spec.apha/nil in :path or :reason"
-   [error-maps]
-   (if (> (count error-maps) 1)
-       (->> error-maps
+   "problem-maps looks like [{:path [:a :b ...] ~~} {:path [] ~~} ...]
+   Filters through problem-maps removing any map that contains :clojure.spec.apha/nil in :path or :reason"
+   [problem-maps]
+   (if (> (count problem-maps) 1)
+       (->> problem-maps
             (filter #(not (has-alpha-nil? %)))
             (filter #(not (contains? % :reason))))
-       error-maps))
+       problem-maps))
 
 ; (defn choose-path
 ;   "Returns correct path based on conditions when given a list which should be of a :clojure.spec.alpha.problems that contains a list of paths.
@@ -107,8 +107,10 @@
 (defn spec-message
   "Takes ex-info data of a spec error, returns a modified message as a string"
   [ex-data]
-  (let [{my-paths :clojure.spec.alpha/problems fn-full-name :clojure.spec.alpha/fn args-val :clojure.spec.alpha/args} ex-data
-        {:keys [path pred val via in]} (-> my-paths
+  (let [{problem-list :clojure.spec.alpha/problems
+         fn-full-name :clojure.spec.alpha/fn
+         args-val :clojure.spec.alpha/args} ex-data
+        {:keys [path pred val via in]} (-> problem-list
                                            filter-extra-spec-errors
                                            first)
         arg-number (first in)

--- a/src/babel/processor.clj
+++ b/src/babel/processor.clj
@@ -82,8 +82,9 @@
   [{:keys [path]}]
   (.contains path :clojure.spec.alpha/nil))
 
-(defn filter-path
-   "Filters through a list of paths removing any hashmap that contains :reason or :clojure.spec.apha/nil"
+(defn filter-extra-spec-errors
+   "error-maps looks like [{:path [:a :b ...] ~~} {:path [] ~~} ...]
+   Filters through error-maps removing any map that contains :clojure.spec.apha/nil in :path or :reason"
    [error-maps]
    (if (> (count error-maps) 1)
        (->> error-maps
@@ -108,8 +109,8 @@
   [ex-data]
   (let [{my-paths :clojure.spec.alpha/problems fn-full-name :clojure.spec.alpha/fn args-val :clojure.spec.alpha/args} ex-data
         {:keys [path pred val via in]} (-> my-paths
-                                           filter-path
-                                           first) ;(first (filter-path my-paths))
+                                           filter-extra-spec-errors
+                                           first)
         arg-number (first in)
         [print-type print-val] (d/type-and-val val)
         fn-name (d/get-function-name (str fn-full-name))

--- a/src/corefns/corefns.clj
+++ b/src/corefns/corefns.clj
@@ -31,7 +31,7 @@
                                                (if num2
                                                   (and (>= strc num1) (>= strc num2) (>= num2 num1))
                                                   (>= strc num1))))
-(defn greater-than-zero? [number] (< 0 number))
+(defn greater-than-zero? [number] (and (number? number)(< 0 number)))
 
 (s/def ::b-length-one b-length1?)
 (s/def ::b-length-two b-length2?)
@@ -229,7 +229,7 @@
 
 (s/fdef clojure.core/contains?
   :args (s/and ::b-length-two
-    (s/cat :collection (s/nilable coll?) :key (s/nilable keyword?))))
+    (s/or :arg-one (s/cat :collection (s/nilable coll?) :key (s/nilable keyword?)))))
 (stest/instrument `clojure.core/contains?)
 
 (s/fdef clojure.core/filter
@@ -248,7 +248,7 @@
 (s/fdef clojure.core/take-nth
   :args (s/and ::b-length-one-to-two
     (s/or :arg-one (s/cat :number ::number-or-lazy)
-          :arg-two (s/cat :number ::greater-than-zero :collection (s/nilable seqable?)))))
+          :arg-two (s/cat :number-greater-than-zero ::greater-than-zero :collection (s/nilable seqable?)))))
 (stest/instrument `clojure.core/take-nth)
 
 (s/fdef clojure.core/take-last


### PR DESCRIPTION
### filter-path  
1. Changes `filter-path` to be `filter-extra-spec-errors`
2. Removes `has-val?` and replaces with `has-alpha-nil?`
3. Refactors function

### spec-message
1. Destructured argument
2. Changed `str`'s to `format`'s